### PR TITLE
Drop legacy KDE and GNOME desktop dirs

### DIFF
--- a/bin/fvwm-crystal.generate-menu
+++ b/bin/fvwm-crystal.generate-menu
@@ -967,9 +967,6 @@ gen_category() {
 		done
 	else
 		case "$2" in
-			/usr/share/gnome/apps*)
-				CATNAME="$(echo ${2} | sed -e 's:/usr/share/gnome/apps::' -e 's:/: :g')"
-				;;
 			*)
 				CATNAME=""
 				;;

--- a/bin/fvwm-crystal.generate-menu
+++ b/bin/fvwm-crystal.generate-menu
@@ -967,17 +967,8 @@ gen_category() {
 		done
 	else
 		case "$2" in
-			/usr/share/applnk*)
-				CATNAME="$(echo ${2} | sed -e 's:/usr/share/applnk::' -e 's:/: :g')"
-				;;
 			/usr/share/gnome/apps*)
 				CATNAME="$(echo ${2} | sed -e 's:/usr/share/gnome/apps::' -e 's:/: :g')"
-				;;
-			/usr/kde/3.5/share/applnk*)
-				CATNAME="$(echo ${2} | sed -e 's:/usr/kde/3.5/share/applnk::' -e 's:/: :g')"
-				;;
-			/usr/kde/3.5/share/apps/kappfinder/apps*)
-				CATNAME="$(echo ${2} | sed -e 's:/usr/kde/3.5/share/apps/kappfinder/apps::' -e 's:/: :g')"
 				;;
 			*)
 				CATNAME=""

--- a/fvwm/preferences/DesktopDirs
+++ b/fvwm/preferences/DesktopDirs
@@ -12,6 +12,3 @@
 /usr/share/applications/kde4
 #/usr/share/gnome/apps
 #/usr/local/share/applications
-#/usr/kde/3.5/share/applications/kde
-#/usr/kde/3.5/share/applnk
-#/usr/kde/3.5/share/apps/kaoofinder/apps

--- a/fvwm/preferences/DesktopDirs
+++ b/fvwm/preferences/DesktopDirs
@@ -10,5 +10,4 @@
 /usr/share/applications
 #/usr/share/applications/kde
 /usr/share/applications/kde4
-#/usr/share/gnome/apps
 #/usr/local/share/applications


### PR DESCRIPTION
Drop support for very old desktop directories of KDE and GNOME, which they stopped supporting already long time ago, or they are effectively unused for many years.